### PR TITLE
metric-learn 0.7.0 :snowflake:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313: yes
+
+upload_channels:
+  - sfe1ed40

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,2 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313: yes
-
 upload_channels:
   - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ test:
     - matplotlib-base
   commands:
     - pip check
-    - pytest test
+    #- pytest test
   imports:
     - metric_learn
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - numpy >=1.11.0
     - python
     - scikit-learn >=0.21.3, <1.3.2
-    - scipy >=0.17.0
+    - scipy >=0.17.0, <1.11.4
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,27 +6,37 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 2b35246a1098d74163b16cc7779e0abfcbf9036050f4caa258e4fee55eb299cc
+  url: https://github.com/scikit-learn-contrib/metric-learn/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 267e982a4fa09e706ab571937a8bde6ec67fe7c80daa1013cd0fa785d31f10e8
 
 build:
-  number: 1
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+  skip: true  # [py<36]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
     - pip
-    - python {{ python_min }}
+    - python
+    - setuptools
+    - wheel
   run:
     - numpy >=1.11.0
-    - python >={{ python_min }}
+    - python
     - scikit-learn >=0.21.3
     - scipy >=0.17.0
 
 test:
+  source_files:
+    - test
+    - pytest.ini
   requires:
-    - python {{ python_min }}
+    - pip
+    - pytest
+    - matplotlib-base
+  commands:
+    - pip check
+    - pytest test
   imports:
     - metric_learn
 
@@ -36,7 +46,6 @@ about:
   license_family: MIT
   license_file: LICENSE.txt
   summary: Python implementations of metric learning algorithms
-
   description: metric-learn contains efficient Python implementations of several popular supervised and weakly-supervised metric learning algorithms. As part of scikit-learn-contrib, the API of metric-learn is compatible with scikit-learn, the leading library for machine learning in Python. This allows to use all the scikit-learn
     routines (for pipelining, model selection, etc) with metric learning algorithms through a unified interface.
   doc_url: http://contrib.scikit-learn.org/metric-learn/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,11 @@ requirements:
   run:
     - numpy >=1.11.0
     - python
+    # <1.3.2 is due to API changes introduced after metric-learn 0.7.0 release
+    # which cause a large amount of test failures
     - scikit-learn >=0.21.3, <1.3.2
+    # <1.11.4 is due to segfault on osx-64 which later releases after
+    # metric-learn 0.7.0 release
     - scipy >=0.17.0, <1.11.4
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - python
     # <1.3.2 is due to API changes introduced after metric-learn 0.7.0 release
     # which cause a large amount of test failures
-    - scikit-learn >=0.21.3, <1.3.2
+    - scikit-learn >=0.21.3,<1.3.2
     - scipy >=0.17.0
     # address segfault on osx-64
     - blas=*=openblas  # [osx and x86_64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,8 @@ requirements:
     # which cause a large amount of test failures
     - scikit-learn >=0.21.3, <1.3.2
     - scipy >=0.17.0
+    # address segfault on osx-64
+    - blas=*=openblas  # [osx and x86_64]
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
   run:
     - numpy >=1.11.0
     - python
-    - scikit-learn >=0.21.3
+    - scikit-learn >=0.21.3, <1.3.2
     - scipy >=0.17.0
 
 test:
@@ -36,7 +36,7 @@ test:
     - matplotlib-base
   commands:
     - pip check
-    #- pytest test
+    - pytest test
   imports:
     - metric_learn
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,15 +41,15 @@ test:
     - metric_learn
 
 about:
-  home: http://github.com/scikit-learn-contrib/metric-learn
+  home: https://github.com/scikit-learn-contrib/metric-learn
   license: MIT
   license_family: MIT
   license_file: LICENSE.txt
   summary: Python implementations of metric learning algorithms
   description: metric-learn contains efficient Python implementations of several popular supervised and weakly-supervised metric learning algorithms. As part of scikit-learn-contrib, the API of metric-learn is compatible with scikit-learn, the leading library for machine learning in Python. This allows to use all the scikit-learn
     routines (for pipelining, model selection, etc) with metric learning algorithms through a unified interface.
-  doc_url: http://contrib.scikit-learn.org/metric-learn/
-  dev_url: http://github.com/scikit-learn-contrib/metric-learn
+  doc_url: https://contrib.scikit-learn.org/metric-learn/
+  dev_url: https://github.com/scikit-learn-contrib/metric-learn
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,9 +28,7 @@ requirements:
     # <1.3.2 is due to API changes introduced after metric-learn 0.7.0 release
     # which cause a large amount of test failures
     - scikit-learn >=0.21.3, <1.3.2
-    # <1.11.4 is due to segfault on osx-64 which later releases after
-    # metric-learn 0.7.0 release
-    - scipy >=0.17.0, <1.11.4
+    - scipy >=0.17.0
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,9 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<36]
+  skip: True  # [py<36]
+  # skipping py312 because of missing scikit-learn <1.3.2
+  skip: True  # [py>311]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,7 @@ requirements:
     # which cause a large amount of test failures
     - scikit-learn >=0.21.3,<1.3.2
     - scipy >=0.17.0
+  run_constrained:
     # address segfault on osx-64
     - blas=*=openblas  # [osx and x86_64]
 


### PR DESCRIPTION
metric-learn 0.7.0 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-5179]
- dev_url:        https://github.com/scikit-learn-contrib/metric-learn/tree/v0.7.0
- conda_forge:    https://github.com/conda-forge/metric-learn-feedstock/blob/main/recipe/meta.yaml
- pypi:           https://pypi.org/project/metric-learn/0.7.0
- pypi inspector: https://inspector.pypi.io/project/metric-learn/0.7.0

### Explanation of changes:

- ```scikit-learn``` has been restricted to ```<1.3.2``` because of API compatibility resulting from upstream tests
  - on **Sept 29 2023** ```metric-learn 0.7.0``` was released
  - at that point in time the latest release of ```scikit-learn``` was ```1.3.1```, so the upper bound makes sure no API compatibility issues would have resulted upon the ```0.7.0``` release
- ```osx-64``` throws a segfault right at the beginning of tests; since it is pretty hard to debug and not a priority architecture, it has been skipped

[PKG-5179]: https://anaconda.atlassian.net/browse/PKG-5179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ